### PR TITLE
Use `.env` file

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,1 @@
+SLACK_WEBHOOK_URL="https://hooks.slack.com/services/xxxx"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .serverless/
 .webpack/
 build/
+.env

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Here are the actions you might take:
 
 ## Deploy the code
 
-Deploy the service using: `SLACK_WEBHOOK_URL="https://hooks.slack.com/services/xxxx" serverless deploy`
+Create the `.env`: `cp .env.dist .env` and then update the Slack webhook url in the file.
+
+Deploy the service using: `serverless deploy`
 
 By default
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,7 @@
 frameworkVersion: ">=3.17.0"
 
 service: serverless-provisioned-memory-report
+useDotenv: true
 
 plugins:
     - serverless-webpack


### PR DESCRIPTION
Instead of passing env variable to the CLI, use `.env` file which is handled automatically by Serverless.