### PR TITLE
Fix CloudWatch query handling and input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Analyse logs from Lambdas to determine the provisioned memory usage (defined, ma
 ## How it works
 
 1. We first fetch all your lambdas
-2. For each lambda, we run a custom CloudWatchLogs query to determine: provisoned memory, max used memory and over provisioned memory
+2. For each lambda, we run a custom CloudWatchLogs query to determine: provisioned memory, max used memory and over provisioned memory
 3. Once all queries are complete, we send the report to your Slack
 
 Here is the Step Functions definition:
@@ -20,7 +20,7 @@ Here is the Step Functions definition:
 
 Once you got the report, you can take action from it based on the _over_ column:
 - if the value is negative, it means you must increase the memory size of that lambda because it often hit the limit
-- if the value is high (compared to the defined memory), it means you can decrease the memory to something more that the max used
+- if the value is high (compared to the defined memory), it means you can decrease the memory to something more than the max used
 - if the value is between ~50 & ~100, the defined memory is fine!
 
 For example, take that report:
@@ -35,8 +35,8 @@ function3                 300         286      214       72
 
 Here are the actions you might take:
 
-1. `function1` must have more memory, define it to `1024` (or at least to something more that `768`)
-2. `function2` is over provisioned by a lot, lower it to `128`
+1. `function1` must have more memory, define it to `1024` (or at least to something more than `768`)
+2. `function2` is over-provisioned by a lot, lower it to `128`
 3. `function3` is fine
 
 ## Prerequisites

--- a/functions/extractQueryResult.js
+++ b/functions/extractQueryResult.js
@@ -7,7 +7,7 @@ export async function handler(event) {
     queryId: event.queryId,
   })
 
-  if (result.status === 'Running') {
+  if (['Running', 'Scheduled'].includes(result.status)) {
     console.info(`Query "${event.queryId}" is still running...`)
 
     return {
@@ -16,13 +16,17 @@ export async function handler(event) {
     }
   }
 
+  if (result.status !== 'Complete') {
+    throw new Error(`Query "${event.queryId}" ended with status: ${result.status}`)
+  }
+
   const mbResults = {
-    provisonedMemoryMB: 0,
+    provisionedMemoryMB: 0,
     maxMemoryUsedMB: 0,
     overProvisionedMB: 0,
   }
 
-  if (result.results.length !== 0) {
+  if (result.results?.length > 0) {
     result.results[0].forEach((res) => {
       mbResults[res.field] = res.value
     })

--- a/functions/listLambdas.js
+++ b/functions/listLambdas.js
@@ -1,13 +1,38 @@
 import { Lambda } from '@aws-sdk/client-lambda'
 
-export async function handler(event) {
+function parsePositiveInteger(value, defaultValue, name, maxValue = Number.POSITIVE_INFINITY) {
+  const parsedValue = Number(value ?? defaultValue)
+
+  if (!Number.isInteger(parsedValue) || parsedValue < 1 || parsedValue > maxValue) {
+    const maxMessage = Number.isFinite(maxValue) ? ` lower than or equal to ${maxValue}` : ''
+
+    throw new Error(`${name} must be a positive integer${maxMessage}`)
+  }
+
+  return parsedValue
+}
+
+export async function handler(event = {}) {
   // which is also the limit of queries to run in parallel on CloudWatchLogs
-  const numberPerPage = process.env.CLOUDWATCH_LOGS_PARALLEL_QUERIES
+  const numberPerPage = parsePositiveInteger(
+    process.env.CLOUDWATCH_LOGS_PARALLEL_QUERIES,
+    30,
+    'CLOUDWATCH_LOGS_PARALLEL_QUERIES',
+    30
+  )
   const lambda = new Lambda()
   let result
   const functions = []
-  const days = event?.days ?? 7
-  const page = event?.page ?? 1
+  const days = parsePositiveInteger(event.days, 7, 'days', 90)
+  const page = parsePositiveInteger(event.page, 1, 'page')
+
+  if (event.prefix !== undefined && typeof event.prefix !== 'string') {
+    throw new Error('prefix must be a string')
+  }
+
+  if (event.channel !== undefined && typeof event.channel !== 'string') {
+    throw new Error('channel must be a string')
+  }
 
   do {
     result = await lambda.listFunctions({
@@ -51,10 +76,20 @@ export async function handler(event) {
   const nbLambdas = filteredFunctions.length
   const totalPages = Math.ceil(nbLambdas / numberPerPage)
 
-  if (page > totalPages) {
-    console.error(`Given page ${page} is too hight. Total pages: ${totalPages}`)
+  if (nbLambdas === 0) {
+    console.info('Found 0 functions')
 
-    throw new Error('Page is too hight')
+    return {
+      ...options,
+      lambdasLimitReached: false,
+      functions: [],
+    }
+  }
+
+  if (page > totalPages) {
+    console.error(`Given page ${page} is too high. Total pages: ${totalPages}`)
+
+    throw new Error('Page is too high')
   }
 
   if (page > 1) {

--- a/functions/reportToSlack.js
+++ b/functions/reportToSlack.js
@@ -28,7 +28,7 @@ export async function handler(event) {
       data.dataSource.push({
         func,
         defined: report.memorySize,
-        provisioned: Math.round(report.provisonedMemoryMB),
+        provisioned: Math.round(report.provisionedMemoryMB),
         max: Math.round(report.maxMemoryUsedMB),
         over: Math.round(report.overProvisionedMB),
       })
@@ -105,7 +105,7 @@ export async function handler(event) {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `We did not found data for *${noData.length}* functions (\`${noData.join('`, `')}\`).`,
+        text: `We did not find data for *${noData.length}* functions (\`${noData.join('`, `')}\`).`,
       },
     })
   }

--- a/functions/startQuery.js
+++ b/functions/startQuery.js
@@ -2,18 +2,19 @@ import { CloudWatchLogs } from '@aws-sdk/client-cloudwatch-logs'
 
 export async function handler(event) {
   const cloudwatchlogs = new CloudWatchLogs()
-  const timestamp = new Date()
+  const endTime = Math.floor(Date.now() / 1000)
+  const startTime = endTime - event.days * 24 * 60 * 60
   const logGroupName = `/aws/lambda/${event.name}`
 
   const result = await cloudwatchlogs.startQuery({
-    endTime: timestamp.getTime(),
+    endTime,
     queryString: `
         filter @type = "REPORT"
-        | stats max(@memorySize / 1024 / 1024) as provisonedMemoryMB,
+        | stats max(@memorySize / 1024 / 1024) as provisionedMemoryMB,
           max(@maxMemoryUsed / 1024 / 1024) as maxMemoryUsedMB,
-          provisonedMemoryMB - maxMemoryUsedMB as overProvisionedMB
+          provisionedMemoryMB - maxMemoryUsedMB as overProvisionedMB
       `,
-    startTime: timestamp.setDate(timestamp.getDate() - event.days),
+    startTime,
     logGroupName,
   })
 

--- a/tests/extractQueryResult.test.js
+++ b/tests/extractQueryResult.test.js
@@ -1,10 +1,14 @@
-import { CloudWatchLogs } from '@aws-sdk/client-cloudwatch-logs'
+import { CloudWatchLogs, GetQueryResultsCommand } from '@aws-sdk/client-cloudwatch-logs'
 import { mockClient } from 'aws-sdk-client-mock'
 import { handler } from '../functions/extractQueryResult.js'
 
 const awsMock = mockClient(CloudWatchLogs)
 
 describe('Extract Query Result', () => {
+  beforeEach(() => {
+    awsMock.reset()
+  })
+
   it('should handle a running query', async () => {
     awsMock.resolves({
       status: 'Running',
@@ -23,6 +27,24 @@ describe('Extract Query Result', () => {
       queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
       running: true,
     })
+
+    expect(awsMock.commandCalls(GetQueryResultsCommand)[0].firstArg.input).toEqual({
+      queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
+    })
+  })
+
+  it('should handle a scheduled query', async () => {
+    awsMock.resolves({
+      status: 'Scheduled',
+    })
+
+    const result = await handler({
+      name: 'service1-env-function-1',
+      memorySize: 300,
+      queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
+    })
+
+    expect(result.running).toBe(true)
   })
 
   it('should handle a completed query', async () => {
@@ -31,7 +53,7 @@ describe('Extract Query Result', () => {
       results: [
         [
           {
-            field: 'provisonedMemoryMB',
+            field: 'provisionedMemoryMB',
             value: 286,
           },
           {
@@ -57,10 +79,27 @@ describe('Extract Query Result', () => {
       name: 'service1-env-function-1',
       memorySize: 300,
       queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
-      provisonedMemoryMB: 286,
+      provisionedMemoryMB: 286,
       maxMemoryUsedMB: 246,
       overProvisionedMB: 40,
       running: false,
     })
   })
+
+  it.each(['Failed', 'Cancelled', 'Timeout', 'Unknown'])(
+    'should fail when query status is %s',
+    async (status) => {
+      awsMock.resolves({
+        status,
+      })
+
+      await expect(
+        handler({
+          name: 'service1-env-function-1',
+          memorySize: 300,
+          queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
+        })
+      ).rejects.toThrow(`Query "d992b1d7-d217-440e-834d-ca3fab97fd58" ended with status: ${status}`)
+    }
+  )
 })

--- a/tests/listLambdas.test.js
+++ b/tests/listLambdas.test.js
@@ -1,11 +1,14 @@
-import { Lambda } from '@aws-sdk/client-lambda'
+import { Lambda, ListFunctionsCommand } from '@aws-sdk/client-lambda'
 import { mockClient } from 'aws-sdk-client-mock'
 import { handler } from '../functions/listLambdas.js'
 
 const awsMock = mockClient(Lambda)
-process.env.CLOUDWATCH_LOGS_PARALLEL_QUERIES = 20
 
 describe('List Lambdas', () => {
+  beforeEach(() => {
+    awsMock.reset()
+    process.env.CLOUDWATCH_LOGS_PARALLEL_QUERIES = 20
+  })
   it('should list all lambdas', async () => {
     awsMock.resolves({
       Functions: [
@@ -110,6 +113,72 @@ describe('List Lambdas', () => {
     expect(result.totalPages).toBe(2)
   })
 
+  it('should handle AWS pagination', async () => {
+    awsMock
+      .on(ListFunctionsCommand)
+      .resolvesOnce({
+        NextMarker: 'next-page',
+        Functions: [
+          {
+            FunctionName: 'service-env-function-2',
+            MemorySize: 512,
+          },
+        ],
+      })
+      .resolvesOnce({
+        Functions: [
+          {
+            FunctionName: 'service-env-function-1',
+            MemorySize: 768,
+          },
+        ],
+      })
+
+    const result = await handler({})
+
+    expect(result.functions).toEqual([
+      { name: 'service-env-function-1', memorySize: 768, days: 7 },
+      { name: 'service-env-function-2', memorySize: 512, days: 7 },
+    ])
+    expect(awsMock.commandCalls(ListFunctionsCommand)).toHaveLength(2)
+    expect(awsMock.commandCalls(ListFunctionsCommand)[0].firstArg.input).toEqual({
+      Marker: null,
+    })
+    expect(awsMock.commandCalls(ListFunctionsCommand)[1].firstArg.input).toEqual({
+      Marker: 'next-page',
+    })
+  })
+
+  it('should handle an empty filtered result', async () => {
+    awsMock.resolves({
+      Functions: [
+        {
+          FunctionName: 'service-env-function-1',
+          MemorySize: 768,
+        },
+      ],
+    })
+
+    await expect(handler({ prefix: 'unknown' })).resolves.toEqual({
+      lambdasLimitReached: false,
+      prefix: 'unknown',
+      channel: '#general',
+      days: 7,
+      page: 1,
+      functions: [],
+    })
+  })
+
+  it('should validate input options', async () => {
+    await expect(handler({ days: 0 })).rejects.toThrow('days must be a positive integer')
+    await expect(handler({ days: 91 })).rejects.toThrow(
+      'days must be a positive integer lower than or equal to 90'
+    )
+    await expect(handler({ page: 0 })).rejects.toThrow('page must be a positive integer')
+    await expect(handler({ prefix: 123 })).rejects.toThrow('prefix must be a string')
+    await expect(handler({ channel: 123 })).rejects.toThrow('channel must be a string')
+  })
+
   it('should fail when page is too high', async () => {
     awsMock.resolves({
       Functions: [
@@ -120,6 +189,6 @@ describe('List Lambdas', () => {
       ],
     })
 
-    await expect(handler({ page: 2 })).rejects.toThrow('Page is too hight')
+    await expect(handler({ page: 2 })).rejects.toThrow('Page is too high')
   })
 })

--- a/tests/reportToSlack.test.js
+++ b/tests/reportToSlack.test.js
@@ -36,7 +36,7 @@ describe('Report To Slack', () => {
           name: 'service1-env-function-1',
           memorySize: 300,
           queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
-          provisonedMemoryMB: '286',
+          provisionedMemoryMB: '286',
           maxMemoryUsedMB: '246',
           overProvisionedMB: '40',
           running: false,
@@ -71,7 +71,7 @@ describe('Report To Slack', () => {
           name: 'service1-env-function-1',
           memorySize: 300,
           queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
-          provisonedMemoryMB: '286',
+          provisionedMemoryMB: '286',
           maxMemoryUsedMB: '246',
           overProvisionedMB: '40',
           running: false,
@@ -80,7 +80,7 @@ describe('Report To Slack', () => {
           name: 'service1-env-function-2',
           memorySize: 300,
           queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
-          provisonedMemoryMB: 0,
+          provisionedMemoryMB: 0,
           maxMemoryUsedMB: 0,
           overProvisionedMB: 0,
           running: false,
@@ -113,7 +113,7 @@ describe('Report To Slack', () => {
 
     expect(mockCalls.blocks[3].type).toBe('section')
     expect(mockCalls.blocks[3].text.text).toBe(
-      'We did not found data for *1* functions (`service1-env-function-2`).'
+      'We did not find data for *1* functions (`service1-env-function-2`).'
     )
     expect(mockCalls.blocks[3].text.type).toBe('mrkdwn')
   })
@@ -127,7 +127,7 @@ describe('Report To Slack', () => {
           name: 'service1-env-function-1',
           memorySize: 300,
           queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
-          provisonedMemoryMB: '286',
+          provisionedMemoryMB: '286',
           maxMemoryUsedMB: '246',
           overProvisionedMB: '40',
           running: false,
@@ -164,7 +164,7 @@ describe('Report To Slack', () => {
           name: 'service1-env-function-1',
           memorySize: 300,
           queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
-          provisonedMemoryMB: '286',
+          provisionedMemoryMB: '286',
           maxMemoryUsedMB: '246',
           overProvisionedMB: '40',
           running: false,
@@ -198,7 +198,7 @@ describe('Report To Slack', () => {
           name: 'service1-env-function-1',
           memorySize: 300,
           queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
-          provisonedMemoryMB: '286',
+          provisionedMemoryMB: '286',
           maxMemoryUsedMB: '246',
           overProvisionedMB: '40',
           running: false,

--- a/tests/startQuery.test.js
+++ b/tests/startQuery.test.js
@@ -1,10 +1,20 @@
-import { CloudWatchLogs } from '@aws-sdk/client-cloudwatch-logs'
+import { CloudWatchLogs, StartQueryCommand } from '@aws-sdk/client-cloudwatch-logs'
 import { mockClient } from 'aws-sdk-client-mock'
 import { handler } from '../functions/startQuery.js'
 
 const awsMock = mockClient(CloudWatchLogs)
 
 describe('Start Query', () => {
+  beforeEach(() => {
+    awsMock.reset()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-01-08T00:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('should start the query', async () => {
     awsMock.resolves({
       queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
@@ -13,13 +23,24 @@ describe('Start Query', () => {
     const event = {
       name: 'service1-env-function-1',
       memorySize: 300,
+      days: 7,
     }
 
     const result = await handler(event)
     expect(result).toEqual({
       name: 'service1-env-function-1',
       memorySize: 300,
+      days: 7,
       queryId: 'd992b1d7-d217-440e-834d-ca3fab97fd58',
+    })
+
+    const startQueryCalls = awsMock.commandCalls(StartQueryCommand)
+    expect(startQueryCalls).toHaveLength(1)
+    expect(startQueryCalls[0].firstArg.input).toEqual({
+      endTime: 1704672000,
+      queryString: expect.stringContaining('provisionedMemoryMB'),
+      startTime: 1704067200,
+      logGroupName: '/aws/lambda/service1-env-function-1',
     })
   })
 })


### PR DESCRIPTION
- use seconds for CloudWatch Logs queries (instead of milliseconds)
- handle CloudWatch Logs query statuses (not only the Running one)
- validate list lambdas options
- fix provisioned memory typos